### PR TITLE
Fix esbuild warning when using dynamic require

### DIFF
--- a/packages/node/src/integrations/modules.ts
+++ b/packages/node/src/integrations/modules.ts
@@ -4,12 +4,21 @@ import { dirname, join } from 'path';
 
 let moduleCache: { [key: string]: string };
 
+/** Extract information about paths */
+function getPaths(): string[] {
+  try {
+    return require.cache ? Object.keys(require.cache as Record<string, unknown>) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
 /** Extract information about package.json modules */
 function collectModules(): {
   [name: string]: string;
 } {
   const mainPaths = (require.main && require.main.paths) || [];
-  const paths = require.cache ? Object.keys(require.cache as Record<string, unknown>) : [];
+  const paths = getPaths();
   const infos: {
     [name: string]: string;
   } = {};


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [X] If you've added code that should be tested, please add tests (Refactor that doesn't change behaviour)
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Given a project that uses esbuild as a build tool, this warning is prompt when the `@sentry/node` dependency is added to the project, This PR removes the warning.

```bash
Compiling with esbuild...
 > node_modules/@sentry/node/dist/integrations/modules.js: warning: Indirect calls to "require" will not be bundled (surround with a try/catch to silence this warning)
    9 │     var paths = require.cache ? Object.keys(require.cache) : [];
      ╵                 ~~~~~~~
```